### PR TITLE
Support Thunderbird 38.x

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -37,7 +37,7 @@
       <!-- Thunderbird -->
 	  <RDF:Description em:id="{3550f703-e582-4d05-9a08-453d09bdfdc6}"
 	                   em:minVersion="3.0"
-	                   em:maxVersion="3.1.*" />
+	                   em:maxVersion="38.*" />
 	</em:targetApplication>
   </RDF:Description>
 </RDF:RDF>


### PR DESCRIPTION
I'm trying to support Thunderbird 38.x.
I've used Ruler Bar with Thunderbird 38.6. It's almost OK.
But the following messages are shown in error console. I want to fix them.
- [ ] box-align
  
  ```
  警告: 不明なプロパティ 'box-align' が使用されています。 このスタイル宣言は無視されました。
  ソースファイル: chrome://rulerbar/skin/rulerbar.css
  行: 38, 列: 10
  ソースコード:
  box-align: start;
  ```
- [x] gCurrentMailSendCharset
  
  ```
  エラー: ReferenceError: gCurrentMailSendCharset is not defined
  ソースファイル: chrome://rulerbar/content/messengercomposeOverlay.js
  行: 446
  ```
- [ ] Mutation Event
  
  ```
  警告: Mutation Event の使用は推奨されません。代わりに MutationObserver を使用してください。
  ソースファイル: chrome://rulerbar/content/messengercomposeOverlay.js
  行: 555
  ```
- [ ] about:blank
  
  ```
  セキュリティエラー: about:blank のコンテンツが chrome://messenger/skin/messageBody.css を読み込みまたはリンクすることは禁止されています。
  ```
